### PR TITLE
feat: Improve grist docker image

### DIFF
--- a/dockerfiles/grist/Dockerfile
+++ b/dockerfiles/grist/Dockerfile
@@ -2,39 +2,24 @@ ARG GRIST_VERSION=1.1.14
 
 FROM gristlabs/grist:$GRIST_VERSION
 
-WORKDIR /grist/static
-
 ARG LASUITE_VERSION=1.0.1
 ARG LASUITE_ARCHIVE=gouvfr-lasuite-integration-$LASUITE_VERSION.tgz 
 
-RUN apt-get update
-RUN apt-get install -y wget
+RUN apt-get update &&\
+  apt-get install -y wget &&\
+  cd /grist/static &&\
+  wget https://github.com/numerique-gouv/lasuite-integration/releases/download/integration-v$LASUITE_VERSION/$LASUITE_ARCHIVE &&\
+  tar -zxvf $LASUITE_ARCHIVE &&\
+  # Archive is extracted as "package"
+  # We move it to @gouvfr-lasuite/integration to be complient with
+  # https://integration.lasuite.numerique.gouv.fr/guides/gaufre/
+  mkdir @gouvfr-lasuite &&\
+  mv package @gouvfr-lasuite/integration &&\
+  rm $LASUITE_ARCHIVE &&\
+  apt-get remove --purge -y wget
 
-RUN wget https://github.com/numerique-gouv/lasuite-integration/releases/download/integration-v$LASUITE_VERSION/$LASUITE_ARCHIVE
-RUN tar -zxvf $LASUITE_ARCHIVE
-
-# Archive is extracted as "package"
-# We move it to @gouvfr-lasuite/integration to be complient with
-# https://integration.lasuite.numerique.gouv.fr/guides/gaufre/
-RUN mkdir @gouvfr-lasuite
-RUN mv package @gouvfr-lasuite/integration
-
-RUN rm $LASUITE_ARCHIVE 
-
-COPY ressources/* ./
-RUN mv marianne-48x48.png ui-icons/Logo/
-
-RUN apt-get remove --purge -y wget
-
-WORKDIR /grist
-
-RUN \
-  groupadd grist -g 10022 && \
-  useradd -ms /bin/bash grist -g grist -u 10022 && \
-  chown -R grist:grist /grist && \
-  chown -R grist:grist /persist
-
-USER grist
+COPY ressources/* /grist/static/
+RUN mv /grist/static/marianne-48x48.png /grist/static/ui-icons/Logo/
 
 # Variable to force grist to use custom.css and dinum-custom.js
 ENV APP_STATIC_INCLUDE_CUSTOM_CSS true


### PR DESCRIPTION
J'ai viré la partie chown et groupadd vu qu'il y a une PR pour gérer ça côté gristlabs.

D'ailleurs quand ce sera merge de leur côté, il faudra sans doute qu'on modifie notre dockerfile. 

En attendant voilà ce que ça donne : 

avant :
![2024-06-14_17-32](https://github.com/numerique-gouv/dockerfiles/assets/22145127/65b7c791-69d2-45e0-8e44-c7ef4d6b90fa)
après:
![2024-06-14_17-32_1](https://github.com/numerique-gouv/dockerfiles/assets/22145127/a1eb0793-91d2-46fb-b6f9-7d502087c0e7)

Image grist actuelle : 
![2024-06-14_17-33](https://github.com/numerique-gouv/dockerfiles/assets/22145127/303c1a63-fcdc-44fa-b1c5-e8b9e8a0c855)

Ça me semble plus cohérent