### PR TITLE
feat: fix contrats in custom colors grist

### DIFF
--- a/dockerfiles/grist/ressources/custom.css
+++ b/dockerfiles/grist/ressources/custom.css
@@ -22,7 +22,7 @@
   --grist-color-lighter-blue: #0078f3 !important;
   --grist-color-light-blue: #0063cb !important;
   --grist-color-cursor: #000091 !important;
-  --grist-color-selection: rgba(128,128,254,0.15) !important;
+  --grist-color-selection: rgba(137,137,243,0.15) !important;
   --grist-color-selection-opaque: #ececfe !important;
   --grist-color-selection-darker-opaque: #e3e3fd !important;
   --grist-color-inactive-cursor: #cacafb !important;
@@ -42,11 +42,12 @@
   --grist-control-border: 1px solid #2323ff !important;
   --grist-toast-bg: #040404 !important;
   
-  /* Custom inputs colors*/
+  /* Custom inputs tags colors*/
   --grist-actual-cell-color: #6e6ef2 !important;
   --accent-color: #6e6ef2 !important;
 }
 
+/* START Custom ACL colors */
 .test-rule-permissions [class*=deny] {
   background-color: #ff0000;
 	background-image: linear-gradient(-45deg, #ff0000 14px, white 15px 16px, #ff0000 16px);
@@ -57,3 +58,41 @@
   background-color: #16b378;
   border-color: #16b378;
 }
+/* END Custom ACL colors */
+
+/* START Custom document card in home page colors */
+.test-dm-public {
+  --icon-color: #cecece !important;
+}
+
+.test-dm-pinned-initials {
+  border-color: #cecece !important;
+}
+/* END Custom document card in home page colors */
+
+/* START Custom tooltip colors */
+.test-tooltip {
+  background-color: rgba(255, 255, 255, 0.8) !important;
+  color: #666666 !important;
+}
+
+.test-tooltip-close [style*=CrossSmall]{
+  background-color: #929292;
+}
+/* END Custom tooltip colors */
+
+/* START Custom Fullframe Card View Colors */
+.test-close-button {
+  --icon-color: #929292 !important;
+}
+
+.test-close-button:hover {
+  --icon-color: #cecece !important;
+}
+/* END Custom Fullframe Card View Colors */
+
+/* START Custom toast notification Colors */
+.test-notifier-toast-custom-action {
+  color:#cacafb !important;;
+}
+/* END Custom toast notification Colors */


### PR DESCRIPTION
Modifications to fix lack of contrast between some components after custom css applies.

It fixes three bugs, essentially lack of contrast introduced by "mariannisation"/DSFR custom colors :

## Colors in documents card in home page

STR: 
* Go to your home page

BEFORE:
![image](https://github.com/numerique-gouv/dockerfiles/assets/31125573/367667e2-9edd-4173-9f1c-853a9da637a1)

AFTER:
![image](https://github.com/numerique-gouv/dockerfiles/assets/31125573/2342d9e5-c1bc-4320-bc23-5830fd1ea785)

## Colors in tooltips

STR:
* Add an equal sign in a non-formula column, this make appears a "Convert to Formula" tooltip 

BEFORE:
![image](https://github.com/numerique-gouv/dockerfiles/assets/31125573/7e3969e7-32a0-4fa5-8f87-68ace85b27f3)

AFTER:
![image](https://github.com/numerique-gouv/dockerfiles/assets/31125573/819a25c9-b730-4a3a-a390-bd117443a47a)


## Colors in cards

STR:
* Click on new button
* Select add view
* Select card from table
* On top right of card view click on double arrow to display as fullframe

BEFORE:
![image](https://github.com/numerique-gouv/dockerfiles/assets/31125573/afe791f3-504b-415c-868f-57f5e98d908d)

AFTER:
![image](https://github.com/numerique-gouv/dockerfiles/assets/31125573/5525ad97-7682-4f42-9306-381a7cad261b)

## Undo Discard notification

STR:
* Delete a row

BEFORE: 
![image](https://github.com/numerique-gouv/dockerfiles/assets/31125573/8ee61e9c-c5b8-457e-b3ac-c4465fca2e9f)

AFTER:
![image](https://github.com/numerique-gouv/dockerfiles/assets/31125573/7982a79b-88a3-4cc6-a004-cc0a3e2cd30f)