### PR TITLE
Fix JS error on document access denied page

### DIFF
--- a/dockerfiles/grist/ressources/dinum-custom.js
+++ b/dockerfiles/grist/ressources/dinum-custom.js
@@ -133,10 +133,13 @@
 
 window.addEventListener('load', async (event) => {
   await waitForElm('body.interface-full');
-  // gristApp.topAppModel.appObs is not populated at that point, listen for the observer to their first change
-  
+  const appObs = gristApp.topAppModel && gristApp.topAppModel.appObs;
+  if (!appObs) {
+    return;
+  }
+  // appObs is not populated at that point, listen for the observer to their first change
   let listener; 
-  listener = gristApp.topAppModel.appObs.addListener( async (appObs) => {
+  listener = appObs.addListener( async (appObs) => {
     // Gauffre must be displayed only in home pages
     if (appObs.pageType.get() !== "home"){
       return 1;


### PR DESCRIPTION
## Bug constaté

STR:
1. Ouvrir une fenêtre de navigation privée
2. Aller à ce lien : https://grist.incubateur.net/o/docs/81A6LpVcY6g7/Dummy-form

Vous devriez voir ce message sous Firefox : 
![erreur dans Firefox](https://github.com/numerique-gouv/dockerfiles/assets/371705/6dab033b-33e9-4604-b375-f05eabd82944)

Ou sur Chrom*:
![erreur sur Chrome](https://github.com/numerique-gouv/dockerfiles/assets/371705/adc9bd5d-7bbc-4bab-b44a-43ab2305d8b0)

## Comportement attendu

Ce message d'erreur ne devrait pas apparaître, seule la page d'erreur nous intéresse

## Correction proposée

S'assurer que `appObs` est bien défini.
