### PR TITLE
feat: CHANGE base image from grist to grist-oss

### DIFF
--- a/dockerfiles/grist/Dockerfile
+++ b/dockerfiles/grist/Dockerfile
@@ -1,6 +1,6 @@
 ARG GRIST_VERSION=1.1.18
 
-FROM gristlabs/grist:$GRIST_VERSION
+FROM gristlabs/grist-oss:$GRIST_VERSION
 
 ARG LASUITE_VERSION=1.0.2
 ARG LASUITE_ARCHIVE=gouvfr-lasuite-integration-$LASUITE_VERSION.tgz


### PR DESCRIPTION
The image to base our custom image over is now grist-oss.
We change the code accordingly.