### PR TITLE
feat: Maintain our own Dockerfile

### DIFF
--- a/dockerfiles/grist/Dockerfile
+++ b/dockerfiles/grist/Dockerfile
@@ -85,15 +85,43 @@ RUN \
 ## Sandbox collection stage
 ################################################################################
 
-# Fetch gvisor-based sandbox. Note, to enable it to run within default
+# A recipe for building the gvisor runsc sandbox. Output is a single file.
+
+# This build stage is adapted from work done by @paulfitz
+# https://github.com/gristlabs/gvisor/commit/4208b8fe4e19bb7473cee8bec444c7cae6171d8b
+# Note, to enable it to run within default
 # unprivileged docker, layers of protection that require privilege have
 # been stripped away, see https://github.com/google/gvisor/issues/4371
-# The standalone sandbox binary is built on buster, but remains compatible
-# with recent Debian.
 # If you'd like to use unmodified gvisor, you should be able to just drop
 # in the standard runsc binary and run the container with any extra permissions
 # it needs.
-FROM docker.io/gristlabs/gvisor-unprivileged:buster AS sandbox
+
+FROM golang:1.24.1 AS sanbox-builder
+
+# Fetch fork of gvisor supporting an --unprivileged flag.
+# See https://github.com/google/gvisor/issues/4371
+WORKDIR /
+
+RUN \
+  git clone https://github.com/gristlabs/gvisor.git
+
+WORKDIR /gvisor
+
+# Checkout to the wanted commit of the go branch of gvisor.
+# To avoid some complexity we want to build from the go branch rather than with bazel
+# Then cherry pick the fork modifications.
+RUN \
+  git fetch origin bd77833a87a6a58981b1db90a71b961937d74bac && \
+  git checkout bd77833a87a6a58981b1db90a71b961937d74bac && \
+  git cherry-pick -n 4f03d181471cb965f378db4fb5304cb5a9b2843c
+
+RUN \
+  go mod download && \
+  mkdir out && \
+  CGO_ENABLED=0 GO111MODULE=on go build -o out ./...
+
+RUN \
+  strip -s out/runsc
 
 ################################################################################
 ## Run-time stage
@@ -133,7 +161,7 @@ RUN \
   ldconfig /etc/ld.so.conf.d
 
 # Copy runsc.
-COPY --from=sandbox /runsc /usr/bin/runsc
+COPY --from=sanbox-builder /gvisor/out/runsc /usr/bin/runsc
 
 # Add files needed for running server.
 COPY --from=sources /grist-core/package.json /grist/package.json


### PR DESCRIPTION
## Context

To have more power over security and versions pining, we choose to maintain our own version of DockerFile.

We choose Alpine images for their lightness and more up to date packages.
It also remove uneeded/unmaintained python 2.

Ideally when grist-core will drop python 2 we will propose this version to replace the current community one.

At current state `Dockerfile` builds from grist-core git sources.
Its purpose is to propose a less vulnerable image than the community one.
`Dockerfile.custom` is used to build custom images for ANCT and DINUM over the previous one.

## Steps to reproduce

```bash
git clone git@github.com:numerique-gouv/dockerfiles.git
git clone git@github.com:gristlabs/grist-core.git
cp dockerfiles/dockerfiles/grist/Dockerfile.alpine grist-core/Dockerfile
cd grist-core
docker build --tag grist-alpine:test1 --file Dockerfile .
docker run -p 8484:8484 grist-alpine:test1
```

## TODOs

TODO (with effort in grist-core) :

* update generation of gvisor/runsc config in https://github.com/gristlabs/grist-core/blob/8d2ce5ed0d013ce1b08a90fa497a42f33cbd452a/sandbox/gvisor/run.py


## Diff with [grist-core DockerFile](https://github.com/gristlabs/grist-core/blob/main/Dockerfile)

```diff
--- Dockerfile	2025-02-21 10:50:29.834894535 +0100
+++ Dockerfile.alpine	2025-02-24 11:16:31.175714029 +0100
@@ -10,7 +10,7 @@
 ## Javascript build stage
 ################################################################################
 
-FROM node:22-bookworm AS builder
+FROM node:22.14.0-alpine3.21 AS builder
 
 # Install all node dependencies.
 WORKDIR /grist
@@ -35,51 +35,31 @@
 COPY buildtools /grist/buildtools
 # Copy locales files early. During build process they are validated.
 COPY static/locales /grist/static/locales
-RUN yarn run build:prod
+
+# Add bash needed by build:prod and make needed by optional pyodide
+RUN \
+  apk update && \
+  apk --no-cache add bash=5.2.37-r0 make=4.4.1-r2 && \
+  yarn run build:prod && \
 # We don't need them anymore, they will by copied to the final image.
-RUN rm -rf /grist/static/locales
+  rm -rf /grist/static/locales
 
 
 # Prepare material for optional pyodide sandbox
 COPY sandbox/pyodide /grist/sandbox/pyodide
 COPY sandbox/requirements3.txt /grist/sandbox/requirements3.txt
 RUN \
-  cd /grist/sandbox/pyodide && make setup
+  cd /grist/sandbox/pyodide && \
+  make setup
 
 ################################################################################
 ## Python collection stage
 ################################################################################
 
 # Fetch python3.11
-FROM python:3.11-slim-bookworm AS collector-py3
-ADD sandbox/requirements3.txt requirements3.txt
-RUN \
-  pip3 install -r requirements3.txt
-
-# Fetch <shame>python2.7</shame>
-# This is to support users with old documents.
-# If you have documents with python2.7 formulas, try switching
-# to python3 in the document settings. It'll probably work fine!
-# And we'll be forced to turn off python2 support eventually,
-# the workarounds needed to keep it are getting silly.
-# It doesn't exist in recent Debian, so we need to reach back
-# to buster.
-# Many Python2 imports require the ffi foreign-function interface
-# library binary, of course present on modern debian but with
-# a different ABI (currently version 8, versus version 6 for this
-# version of Python2). We move it from an achitecture-specific location
-# to a standard location so we can pick it up and copy it across later.
-# This will no longer be necessary when support for Python2 is dropped.
-# The Grist data engine code will not work without it.
-FROM debian:buster-slim AS collector-py2
-ADD sandbox/requirements.txt requirements.txt
-RUN \
-  apt update && \
-  apt install -y --no-install-recommends python2 python-pip python-setuptools \
-  build-essential libxml2-dev libxslt-dev python-dev zlib1g-dev && \
-  pip2 install wheel && \
-  pip2 install -r requirements.txt && \
-  find /usr/lib -iname "libffi.so.6*" -exec cp {} /usr/local/lib \;
+FROM python:3.11.11-alpine3.21 AS collector-py3
+COPY sandbox/requirements3.txt requirements3.txt
+RUN pip3 install --no-cache-dir -r requirements3.txt
 
 ################################################################################
 ## Sandbox collection stage
@@ -100,14 +80,17 @@
 ################################################################################
 
 # Now, start preparing final image.
-FROM node:22-bookworm-slim
+FROM node:22.14.0-alpine3.21
 
-# Install curl for docker healthchecks, libexpat1 and libsqlite3-0 for python3
+# Install curl for docker healthchecks, libexpat1 and (libsqlite3-0 maybe we need to put it back) for python3
 # library binary dependencies, and procps for managing gvisor processes.
-RUN \
-  apt-get update && \
-  apt-get install -y --no-install-recommends curl libexpat1 libsqlite3-0 procps tini && \
-  rm -rf /var/lib/apt/lists/*
+# Bash to run image entrypoint
+# setpriv is used in docker_entrypoint.sh
+# dirty symbolic link to follow docker_entrypoint.sh expectations
+RUN \
+  apk update && \
+  apk --no-cache add bash=5.2.37-r0 curl=8.12.1-r0 libexpat=2.6.4-r0 procps-ng=4.0.4-r2 setpriv=2.40.4-r0 tini=0.19.0-r3 && \
+  ln -s /sbin/tini /usr/bin/tini
 
 # Keep all storage user may want to persist in a distinct directory
 RUN mkdir -p /persist/docs
@@ -118,34 +101,26 @@
 COPY --from=builder /grist/_build /grist/_build
 COPY --from=builder /grist/static /grist/static-built
 
-# Copy python2 files.
-COPY --from=collector-py2 /usr/bin/python2.7 /usr/bin/python2.7
-COPY --from=collector-py2 /usr/lib/python2.7 /usr/lib/python2.7
-COPY --from=collector-py2 /usr/local/lib/python2.7 /usr/local/lib/python2.7
-# Copy across an older libffi library binary needed by python2.
-# We moved it a bit sleazily to a predictable location to avoid awkward
-# architecture-dependent logic.
-COPY --from=collector-py2 /usr/local/lib/libffi.so.6* /usr/local/lib
-
 # Copy python3 files.
 COPY --from=collector-py3 /usr/local/bin/python3.11 /usr/bin/python3.11
 COPY --from=collector-py3 /usr/local/lib/python3.11 /usr/local/lib/python3.11
 COPY --from=collector-py3 /usr/local/lib/libpython3.11.* /usr/local/lib/
 # Set default to python3
+
 RUN \
-  ln -s /usr/bin/python3.11 /usr/bin/python && \
+  ln -s /usr/bin/python3.11 /usr/bin/python &&\
   ln -s /usr/bin/python3.11 /usr/bin/python3 && \
-  ldconfig
+  ldconfig /etc/ld.so.conf.d
 
 # Copy runsc.
 COPY --from=sandbox /runsc /usr/bin/runsc
 
 # Add files needed for running server.
-ADD package.json /grist/package.json
-ADD bower_components /grist/bower_components
-ADD sandbox /grist/sandbox
-ADD plugins /grist/plugins
-ADD static /grist/static
+COPY package.json /grist/package.json
+COPY bower_components /grist/bower_components
+COPY sandbox /grist/sandbox
+COPY plugins /grist/plugins
+COPY static /grist/static
 
 # Make optional pyodide sandbox available
 COPY --from=builder /grist/sandbox/pyodide /grist/sandbox/pyodide
@@ -161,7 +136,7 @@
 # RUN chmod -R o+rX /grist
 
 # Add a user to allow de-escalating from root on startup
-RUN useradd -ms /bin/bash grist
+RUN adduser -Ds /bin/bash grist
 ENV GRIST_DOCKER_USER=grist \
     GRIST_DOCKER_GROUP=grist
 WORKDIR /grist
```