### PR TITLE
feat: change grist contact mail

### DIFF
--- a/dockerfiles/grist/ressources/DINUM/custom.js
+++ b/dockerfiles/grist/ressources/DINUM/custom.js
@@ -40,7 +40,7 @@
       timeZone: 'Europe/Paris',
     });
 
-    const contactMail = "contact@grist.numerique.gouv.fr"
+    const contactMail = "grist@numerique.gouv.fr"
 
     dialog.innerHTML = `
         <p>


### PR DESCRIPTION
Grist contact mail for dinum instance has changed 
contact@grist.numerique.gouv.fr -> grist@numerique.gouv.fr