### PR TITLE
fix: define workdir to be consistent with upstream image endpoint and cmd

### DIFF
--- a/dockerfiles/grist/Dockerfile.custom
+++ b/dockerfiles/grist/Dockerfile.custom
@@ -24,6 +24,10 @@ RUN if [ "$BUILD_ENV" = "DINUM" ]; then \
 
 COPY ressources/$BUILD_ENV/ /grist/static/
 
+# Set workdir to /grist to be consistent with enpoint and CMD
+# defined in lasuite/grist main images
+WORKDIR /grist
+
 # Variable to force grist to use custom.css and custom.js
 ENV APP_STATIC_INCLUDE_CUSTOM_CSS true
 ENV GRIST_INCLUDE_CUSTOM_SCRIPT_URL /v/unknown/custom.js


### PR DESCRIPTION
It appears that adding `WORKDIR /grist/static` without bring it back to `WORKDIR /grist` at the end of Dockerfile.custom breaks relative pathes declared in `endpoint` and `cmd` in `Dockerfile`
This PR fixes this