### PR TITLE
🔧(github actions): Autoupgrade Grist image from upstream Github repo

### DIFF
--- a/.github/workflows/autoupdate-grist.yml
+++ b/.github/workflows/autoupdate-grist.yml
@@ -1,0 +1,35 @@
+name: Update GRIST_VERSION
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Tous les jours à 2h00
+  workflow_dispatch: # Déclenchement manuel
+
+jobs:
+  check-and-update-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sync version from grist-core with ours
+        id: get_latest_release
+        run: |
+          latest_release=$(curl -s https://api.github.com/repos/gristlabs/grist-core/releases/latest | jq -r .name)
+          # See https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
+          normalized_latest_release=${latest_release/#v/}
+
+          sed -i "s/ARG GRIST_VERSION=.*/ARG GRIST_VERSION=${normalized_latest_release}/" dockerfiles/grist/Dockerfile{,.custom}
+          echo "title=⬆️(grist): bump image to ${normalized_latest_release}" >> $GITHUB_OUTPUT
+          echo "body=See the release notes there: https://github.com/gristlabs/grist-core/releases/tag/${latest_release}" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "${{ steps.get_latest_release.outputs.title }}\n\n${{ steps.get_latest_release.outputs.body }}"
+          title: "${{ steps.get_latest_release.outputs.title }}"
+          body: "${{ steps.get_latest_release.outputs.body }}"
+          branch: bump-grist
+          add-paths: |
+            dockerfiles/grist/Dockerfile*


### PR DESCRIPTION
This is a Github action to automatically upgrade the Grist image when a new version has been released in the upstream Github repository.

A preview of a PR and the generated commits: https://github.com/fflorent/dinum-dockerfiles/pull/3
