### PR TITLE
🔒️(Grist): Add checksum check for grist sources

### DIFF
--- a/.github/workflows/autoupdate-grist.yml
+++ b/.github/workflows/autoupdate-grist.yml
@@ -19,8 +19,11 @@ jobs:
           latest_release=$(curl -s https://api.github.com/repos/gristlabs/grist-core/releases/latest | jq -r .name)
           # See https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
           normalized_latest_release=${latest_release/#v/}
-
+          # Get tarball of latest version and its checksum
+          wget https://github.com/gristlabs/grist-core/archive/refs/tags/${latest_release}.tar.gz || exit 1
+          checksum="sha256:$(shasum -a 256 $latest_release.tar.gz)"
           sed -i "s/ARG GRIST_VERSION=.*/ARG GRIST_VERSION=${normalized_latest_release}/" dockerfiles/grist/Dockerfile{,.custom}
+          sed -i "s/ARG GRIST_CORE_CHECKSUM=.*/ARG GRIST_CORE_CHECKSUM=${checksum}/" dockerfiles/grist/Dockerfile{,.custom}
           echo "title=⬆️(grist): bump image to ${normalized_latest_release}" >> $GITHUB_OUTPUT
           echo "body=See the release notes there: https://github.com/gristlabs/grist-core/releases/tag/${latest_release}" >> $GITHUB_OUTPUT
 

--- a/dockerfiles/grist/Dockerfile
+++ b/dockerfiles/grist/Dockerfile
@@ -1,4 +1,9 @@
+# This variables must be changed at each official releases
+# For now checksum is obtained by performing
+# `shasum -a 256 ${Archive}` locally
+# Could be great to add checksum with releases in gristlabs/grist-core
 ARG GRIST_VERSION=1.6.0
+ARG GRIST_CORE_CHECKSUM="sha256:67140074582bcff4449521404df37f4fc4e75ec386b1828d9f2f4325b779e4af"
 
 ################################################################################
 ## The Grist source can be extended. This is a stub that can be overridden
@@ -11,14 +16,16 @@ FROM scratch AS ext
 ################################################################################
 # Get sources from git stage
 ################################################################################
-FROM alpine/git:v2.47.2 AS sources
+FROM alpine:3.21.3 AS sources
 
 ARG GRIST_VERSION
-
-# Clone grist from GRIST_VERSION tag
-WORKDIR /grist-core
+ARG GRIST_CORE_CHECKSUM
+# Get archive of GRIST_VERSION from official repository
+# And verify that the checksum is the same at each build
+ADD --checksum=${GRIST_CORE_CHECKSUM} https://github.com/gristlabs/grist-core/archive/refs/tags/v${GRIST_VERSION}.tar.gz /
+# Uncompress archive and move result as grist-core
 RUN \
-  git clone --depth 1 -b v$GRIST_VERSION https://github.com/gristlabs/grist-core.git .
+tar -xf /v${GRIST_VERSION}.tar.gz && mv /grist-core-${GRIST_VERSION} /grist-core
 
 ################################################################################
 ## Javascript build stage


### PR DESCRIPTION
This PR adds a checksum check when getting sources preventing a release tag to be moved silently to another commit.